### PR TITLE
Make `confg.force_ssl` configurable (fixes #1)

### DIFF
--- a/config/environments/production.rb.deploy
+++ b/config/environments/production.rb.deploy
@@ -42,7 +42,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  # Can be overriden by setting CONFIG_FORCE_SSL to anything accept "true" in the environment.
+  config.force_ssl = ENV['CONFIG_FORCE_SSL'].nil? || ENV['CONFIG_FORCE_SSL'] == "true"
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       SERVER_NAME: "${SERVER_NAME:-consul.127.0.0.1.nip.io}"
       RAILS_SERVE_STATIC_FILES: "true"
       NEW_RELIC_AGENT_ENABLED: "false"
+      CONFIG_FORCE_SSL: "${CONFIG_FORCE_SSL:-true}"
     depends_on:
       - database
       - memcache

--- a/script/server
+++ b/script/server
@@ -24,6 +24,7 @@ if [ "$SWARM" = "inactive" ] ; then
     docker-compose down
   else
     echo "==> Starting the service..."
+    export CONFIG_FORCE_SSL=${CONFIG_FORCE_SSL:-false}
     docker-compose up -d
   fi
 else


### PR DESCRIPTION
This checks for `CONFIG_FORCE_SSL` in the environment. This should be the default for a production stack, so if it's not present or set to "true" set `config.force_ssl` to boolean `true`, otherwise set to boolean `false`.